### PR TITLE
ESI-2410 - Adding force-delete testcases, and change for session timeout

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -159,7 +159,11 @@ def secret():
     yield
     if globals.replication_test is False :
         manager.delete_secret(secret.metadata.name, secret.metadata.namespace)
-        hpe3par_cli.logout()
+        try:
+            hpe3par_cli.logout()
+        except hpe3parclient.exceptions.HTTPForbidden as e:
+            logging.getLogger().info("Exception in hpe3par_cli.logout, session could have timeout already: %s", e)
+            pass
     if globals.encryption_test:
         manager.delete_secret(enc_secret.metadata.name, enc_secret.metadata.namespace)
         pass

--- a/conftest.py
+++ b/conftest.py
@@ -162,7 +162,7 @@ def secret():
         try:
             hpe3par_cli.logout()
         except hpe3parclient.exceptions.HTTPForbidden as e:
-            logging.getLogger().info("Exception in hpe3par_cli.logout, session could have timeout already: %s", e)
+            logging.getLogger().info("Exception in hpe3par_cli.logout, session could have timeout already: %s" % e)
             pass
     if globals.encryption_test:
         manager.delete_secret(enc_secret.metadata.name, enc_secret.metadata.namespace)

--- a/hpe_3par_kubernetes_manager.py
+++ b/hpe_3par_kubernetes_manager.py
@@ -2684,30 +2684,6 @@ def get_pod_node(yml):
         logging.getLogger().error("Exception in get_pod_node :: %s" % e)
         raise e
 
-def get_current_node_of_pod(obj):
-    """
-    get_current_node_of_pod - This function finds the current worker node where a particular pod created by any Kubernetes object is running on.
-    Parameters:
-        Required:
-            1. (obj): The Pod object, for which to find the current worker node.
-        Optional:
-            None
-        Returns:
-            node_name: The worker node's name on which the pod is running on.
-        Raises:
-            Exception: If there's an error while reading the current node name, it raises an exception.
-    """
-    try:
-        node_name = None
-        logging.getLogger().info("\nReading current node name for pod %s " % obj.items[0].metadata.name)
-        command = "kubectl get pod %s -n %s -o jsonpath='{.spec.nodeName}'" % ( obj.items[0].metadata.name, obj.items[0].metadata.namespace)
-        node_name = get_command_output_string(command)
-        logging.getLogger().info("node_name :: %s" % node_name)
-        return node_name
-    except Exception as e:
-        logging.getLogger().error("Exception in get_current_node_of_pod :: %s" % e)
-        raise e
-
 
 def create_pvc_bulk(yml):
     pvc_map = {}

--- a/hpe_3par_kubernetes_manager.py
+++ b/hpe_3par_kubernetes_manager.py
@@ -57,8 +57,6 @@ def create_service(yml):
             None
         Returns:
             obj: The response object from hpe_create_service_object() Kubernetes API after service is created.
-        Raises:
-            Exception: If there's an error while parsing the YAML body, it catches and raises the exception.
     """
     obj = None
     with open(yml) as f:

--- a/hpe_3par_kubernetes_manager.py
+++ b/hpe_3par_kubernetes_manager.py
@@ -25,6 +25,48 @@ k8s_apps_v1 = client.AppsV1Api()
 timeout = 180
 
 
+def hpe_create_service_object(yml):
+    try:
+        namespace = globals.namespace
+        resp = k8s_core_v1.create_namespaced_service(namespace=namespace, body=yml)
+        logging.getLogger().debug("Service created. Status is %s" % resp.metadata.name)
+        return resp
+    except client.rest.ApiException as e:
+        logging.getLogger().error("Exception in creating service: %s" % e)
+        raise e
+
+
+def create_service(yml):
+    obj = None
+    with open(yml) as f:
+        elements = list(yaml.safe_load_all(f))
+        for el in elements:
+            logging.getLogger().debug("======== kind :: %s " % str(el.get('kind')))
+            if str(el.get('kind')) == "Service":
+                logging.getLogger().info("Creating Service...")
+                obj = hpe_create_service_object(el)
+                logging.getLogger().info("Service %s created." % obj.metadata.name)
+    return obj
+
+def hpe_delete_service_object_by_name(service_name, namespace):
+    try:
+        secret = k8s_core_v1.delete_namespaced_service(service_name, namespace=namespace)
+    except client.rest.ApiException as e:
+        logging.getLogger().error("Exception while deleting Service :: %s" % e)
+        raise e
+
+def delete_service(name, namespace):
+    try:
+        logging.getLogger().info("\nDeleting Service %s from namespace %s..." % (name,namespace))
+        hpe_delete_service_object_by_name(name, namespace=namespace)
+        flag = check_if_deleted(timeout, name, "Service", namespace=namespace)
+        if flag:
+            logging.getLogger().info("\nService %s from namespace %s is deleted." % (name, namespace))
+        return flag
+    except Exception as e:
+        logging.getLogger().error("Exception while deleting service :: %s" % e)
+        raise e
+
 def hpe_create_sc_object(yml):
     try:
         resp = k8s_storage_v1.create_storage_class(body=yml)
@@ -310,12 +352,39 @@ def hpe_list_secret_objects_names(namespace):
         raise e
 
 
+def hpe_list_service_objects(namespace):
+    try:
+        service_list = k8s_core_v1.list_namespaced_service(namespace=namespace)
+        return service_list
+    except client.rest.ApiException as e:
+        #print("Exception :: %s" % e)
+        logging.getLogger().error("Exception :: %s" % e)
+        raise e
+
+
+def hpe_list_service_objects_names(namespace):
+    try:
+        service_names = []
+        service_list = hpe_list_service_objects(namespace=namespace)
+        for service in service_list.items:
+            service_names.append(service.metadata.name)
+
+        return service_names
+    except client.rest.ApiException as e:
+        logging.getLogger().error("Exception :: %s" % e)
+        raise e
+
+
 def hpe_list_pod_objects(namespace, **kwargs):
     try:
-        # print("kwargs :: keys :: %s,\n values :: %s" % (kwargs.keys(), kwargs.values()))
-        # print("value :: %s " % kwargs['label'])
-        # pod_list = k8s_core_v1.list_namespaced_pod(namespace=namespace, label_selector=kwargs['label'])
-        pod_list = k8s_core_v1.list_namespaced_pod(namespace=namespace)
+        pod_list = None
+        logging.getLogger().info("kwargs keys :: %s,\n values :: %s" % (kwargs.keys(), kwargs.values()))
+        if 'label' in kwargs:
+            pod_list = k8s_core_v1.list_namespaced_pod(namespace=namespace, label_selector=kwargs['label'])
+        elif 'field' in kwargs:
+            pod_list = k8s_core_v1.list_namespaced_pod(namespace=namespace, field_selector=kwargs['field'])
+        else:
+            pod_list = k8s_core_v1.list_namespaced_pod(namespace=namespace)
         return pod_list
     except client.rest.ApiException as e:
         #print("Exception :: %s" % e)
@@ -373,6 +442,8 @@ def check_if_deleted(timeout, name, kind, namespace):
             obj_list = hpe_list_deployment_objects_names(namespace=namespace)
         elif kind == 'StatefulSet':
             obj_list = hpe_list_statefulset_objects_names(namespace=namespace)
+        elif kind == 'Service':
+            obj_list = hpe_list_service_objects_names(namespace=namespace)
         else:
             #print("Not a supported kind")
             logging.getLogger().info("Not a supported kind")
@@ -533,14 +604,21 @@ def check_status(timeout_set, name, kind, status, namespace):
         elif kind == 'StatefulSet':
             replica_total = 0
             replica_current = 0
+            replica_ready = 0
 
             if obj.status.replicas is not None:
                 replica_total = obj.status.replicas
 
             if obj.status.current_replicas is not None:
                 replica_current = obj.status.current_replicas
-            if replica_total == replica_current and replica_total > 0:
-                break
+
+            if obj.status.ready_replicas is not None:
+                replica_ready = obj.status.ready_replicas
+
+            if replica_total == replica_current and replica_total > 0 and replica_ready > 0:
+                logging.getLogger().info("Statefulset Current: %s Total: %s Ready: %s" % (replica_current, replica_total, replica_ready))
+                if replica_ready == replica_total:
+                    break
         else:
             if obj.status.phase == status:
                 break
@@ -2162,6 +2240,28 @@ def corden_node(name):
         raise e
 
 
+def stop_kubelet(name):
+    try:
+        command = "systemctl stop kubelet"
+        logging.getLogger().info(command)
+        output = get_command_output(name, command)
+        logging.getLogger().info(output)
+        return output
+    except Exception as e:
+        logging.getLogger().error("Exception while simulating kubelet down on Node %s\n%s" % (name, e))
+        raise e
+
+def start_kubelet(name):
+    try:
+        command = "systemctl start kubelet"
+        logging.getLogger().info(command)
+        output = get_command_output(name, command)
+        logging.getLogger().info(output)
+        return output
+    except Exception as e:
+        logging.getLogger().error("Exception while starting kubelet back up on Node %s\n%s" % (name, e))
+        raise e
+
 def reboot_node(node_name, user='root'):
     flag = True
     try:
@@ -2456,6 +2556,18 @@ def get_pod_node(yml):
         logging.getLogger().error("Exception in get_pod_node :: %s" % e)
         raise e
 
+def get_current_node_of_pod(obj):
+    try:
+        node_name = None
+        logging.getLogger().info("\nReading current node name for pod %s " % obj.items[0].metadata.name)
+        command = "kubectl get pod %s -n %s -o jsonpath='{.spec.nodeName}'" % ( obj.items[0].metadata.name, obj.items[0].metadata.namespace)
+        node_name = get_command_output_string(command)
+        logging.getLogger().info("node_name :: %s" % node_name)
+        return node_name
+    except Exception as e:
+        logging.getLogger().error("Exception in get_current_node_of_pod :: %s" % e)
+        raise e
+
 
 def create_pvc_bulk(yml):
     pvc_map = {}
@@ -2605,7 +2717,7 @@ def delete_dep_bulk(yml, namespace):
         else:
             with open(yml) as f:
                 elements = list(yaml.safe_load_all(f))
-                logging.getLogger().info("\nCreating %s deployment..." % len(elements))
+                logging.getLogger().info("\nDeleting %s deployment..." % len(elements))
                 for el in elements:
                     # print("======== kind :: %s " % str(el.get('kind')))
                     if str(el.get('kind')) == "Secret":

--- a/hpe_3par_kubernetes_manager.py
+++ b/hpe_3par_kubernetes_manager.py
@@ -26,9 +26,20 @@ timeout = 180
 
 
 def hpe_create_service_object(yml):
+    """
+    hpe_create_service_object - This function creates a Kubernetes service using the provided service configuration (body)
+    Parameters:
+        Required:
+            1. (yml): The body of the Kubernetes service configuration.
+        Optional:
+            None
+        Returns:
+            resp: The response object from the Kubernetes API after service creation.
+        Raises:
+            Exception: If there's an error while creating the service, it catches and raises the exception.
+    """
     try:
-        namespace = globals.namespace
-        resp = k8s_core_v1.create_namespaced_service(namespace=namespace, body=yml)
+        resp = k8s_core_v1.create_namespaced_service(namespace=globals.namespace, body=yml)
         logging.getLogger().debug("Service created. Status is %s" % resp.metadata.name)
         return resp
     except client.rest.ApiException as e:
@@ -37,10 +48,21 @@ def hpe_create_service_object(yml):
 
 
 def create_service(yml):
+    """
+    create_service - This function calls the hpe_create_service_object after loading and parsing the YAML service configuration.
+    Parameters:
+        Required:
+            1. (yml): The body of the Kubernetes service configuration.
+        Optional:
+            None
+        Returns:
+            obj: The response object from hpe_create_service_object() Kubernetes API after service is created.
+        Raises:
+            Exception: If there's an error while parsing the YAML body, it catches and raises the exception.
+    """
     obj = None
     with open(yml) as f:
-        elements = list(yaml.safe_load_all(f))
-        for el in elements:
+        for el in list(yaml.safe_load_all(f)):
             logging.getLogger().debug("======== kind :: %s " % str(el.get('kind')))
             if str(el.get('kind')) == "Service":
                 logging.getLogger().info("Creating Service...")
@@ -49,19 +71,48 @@ def create_service(yml):
     return obj
 
 def hpe_delete_service_object_by_name(service_name, namespace):
+    """
+    hpe_delete_service_object_by_name - This function deletes a Kubernetes service using the provided service name, and namespace.
+    Parameters:
+        Required:
+            1. (service_name): The name of the service to be deleted.
+            2. (namespace): The namespace where the service was created under.
+        Optional:
+            None
+        Returns:
+            None
+        Raises:
+            Exception: If there's an error while deleting the service, it catches and raises the exception.
+    """
     try:
-        secret = k8s_core_v1.delete_namespaced_service(service_name, namespace=namespace)
+        service = k8s_core_v1.delete_namespaced_service(service_name, namespace=namespace)
+        logging.getLogger().info(service)
     except client.rest.ApiException as e:
         logging.getLogger().error("Exception while deleting Service :: %s" % e)
         raise e
 
 def delete_service(name, namespace):
+    """
+    delete_service - This function calls hpe_delete_service_object_by_name and checks if the service was deleted.
+    Parameters:
+        Required:
+            1. (service_name): The name of the service to be deleted.
+            2. (namespace): The namespace where the service was created under.
+        Optional:
+            None
+        Returns:
+            flag: (Boolean) The value after checking if the Service was deleted.
+        Raises:
+            Exception: If there's an error while deleting the service, it catches and raises the exception.
+    """
     try:
         logging.getLogger().info("\nDeleting Service %s from namespace %s..." % (name,namespace))
         hpe_delete_service_object_by_name(name, namespace=namespace)
         flag = check_if_deleted(timeout, name, "Service", namespace=namespace)
-        if flag:
-            logging.getLogger().info("\nService %s from namespace %s is deleted." % (name, namespace))
+        if not flag:
+            logging.getLogger().info("\nService %s from namespace %s could not be deleted." % (name, namespace))
+            return False
+        logging.getLogger().info("\nService %s from namespace %s is deleted." % (name, namespace))
         return flag
     except Exception as e:
         logging.getLogger().error("Exception while deleting service :: %s" % e)
@@ -353,6 +404,18 @@ def hpe_list_secret_objects_names(namespace):
 
 
 def hpe_list_service_objects(namespace):
+    """
+    hpe_list_service_objects - This function gets a list of all services and their information under a particular namespace.
+    Parameters:
+        Required:
+            1. (namespace): The namespace under which to list services from Kubernetes.
+        Optional:
+            None
+        Returns:
+            service_list: The list of services under the given namespace.
+        Raises:
+            Exception: If there's an error while collecting the list of services under the namespace, it raises an exception.
+    """
     try:
         service_list = k8s_core_v1.list_namespaced_service(namespace=namespace)
         return service_list
@@ -363,12 +426,22 @@ def hpe_list_service_objects(namespace):
 
 
 def hpe_list_service_objects_names(namespace):
+    """
+    hpe_list_service_objects_names - This function takes a list of V1Service and appends only their names to a list.
+    Parameters:
+        Required:
+            1. (namespace): The namespace under which to list services from Kubernetes.
+        Optional:
+            None
+        Returns:
+            service_list: The list of names of services under a given namespace.
+        Raises:
+            Exception: If there's an error while parsing through list of services, it raises an exception.
+    """
     try:
         service_names = []
         service_list = hpe_list_service_objects(namespace=namespace)
-        for service in service_list.items:
-            service_names.append(service.metadata.name)
-
+        service_names = [service.metadata.name for service in service_list.items]
         return service_names
     except client.rest.ApiException as e:
         logging.getLogger().error("Exception :: %s" % e)
@@ -2187,6 +2260,7 @@ def get_array_version(hpe3par_cli):
 def get_array_model(hpe3par_cli):
     try:
         sysinfo = hpe3par_cli.getStorageSystemInfo()
+        wsapi_version = hpe3par_cli.getWsApiVersion()
         is_primera = hpe3par_cli.is_primera_array()
         logging.getLogger().info("Model of Array - %s :: Is Primera array? %s" % (sysinfo['model'], is_primera))
         return sysinfo['model'],is_primera
@@ -2241,25 +2315,81 @@ def corden_node(name):
 
 
 def stop_kubelet(name):
+    """
+    stop_kubelet - This function stops the "kubelet" service on a particular node.
+    Parameters:
+        Required:
+            1. (name): The name of the node where kubelet will be stopped on.
+        Optional:
+            None
+        Returns:
+            output_status: Status of the kubelet service after stopping the kubelet.
+        Raises:
+            Exception: If there's an error while stopping kubelet service on the node, it raises an exception.
+    """
     try:
         command = "systemctl stop kubelet"
         logging.getLogger().info(command)
         output = get_command_output(name, command)
-        logging.getLogger().info(output)
-        return output
+        logging.getLogger().info("Output of 'systemctl stop kubelet': " % output)
+                
+        output_status = status_kubelet(name)
+        logging.getLogger().info("Kubelet Status on node %s:  %s" % (name,output_status[0]))
+        assert output_status[0]  == "Inactive", "Status of kubelet is %s i.e not Inactive (dead)" % output_status[0]
+
+        return output_status
     except Exception as e:
         logging.getLogger().error("Exception while simulating kubelet down on Node %s\n%s" % (name, e))
         raise e
 
 def start_kubelet(name):
+    """
+    start_kubelet - This function starts the "kubelet" service on a particular node.
+    Parameters:
+        Required:
+            1. (name): The name of the node where kubelet will be started.
+        Optional:
+            None
+        Returns:
+            output_status: Status of the kubelet service after starting the kubelet.
+        Raises:
+            Exception: If there's an error while starting kubelet service on the node, it raises an exception.
+    """
     try:
         command = "systemctl start kubelet"
         logging.getLogger().info(command)
         output = get_command_output(name, command)
-        logging.getLogger().info(output)
-        return output
+        logging.getLogger().info("Output of 'systemctl start kubelet': " % output)
+
+        output_status = status_kubelet(name)
+        logging.getLogger().info("Kubelet Status on node %s:  %s" % (name,output_status[0]))
+        assert output_status[0] == "Active", "Status of kubelet is %s, not Active (running)" % output_status[0]
+
+        return output_status
     except Exception as e:
         logging.getLogger().error("Exception while starting kubelet back up on Node %s\n%s" % (name, e))
+        raise e
+
+def status_kubelet(name):
+    """
+    status_kubelet - This function gets the status of the kubelet service from a particular node, and parses it.
+    Parameters:
+        Required:
+            1. (name): The name of the node to check status of kubelet service.
+        Optional:
+            None
+        Returns:
+            output: Status of the kubelet service after stopping the kubelet.
+        Raises:
+            Exception: If there's an error while checking status of kubelet service on the node, it raises an exception.
+    """
+    try:
+        command = "if systemctl status kubelet | grep -q 'active (running)'; then echo 'Active'; else echo 'Inactive'; fi"
+        output = get_command_output(name, command)
+        logging.getLogger().info("Checking status of kubelet: " % output)
+        return output
+    except Exception as e:
+        logging.getLogger().error("Exception while checking status of Kubelet on Node %s\n%s" % (name, e))
         raise e
 
 def reboot_node(node_name, user='root'):
@@ -2557,6 +2687,18 @@ def get_pod_node(yml):
         raise e
 
 def get_current_node_of_pod(obj):
+    """
+    get_current_node_of_pod - This function finds the current worker node where a particular pod created by any Kubernetes object is running on.
+    Parameters:
+        Required:
+            1. (obj): The Pod object, for which to find the current worker node.
+        Optional:
+            None
+        Returns:
+            node_name: The worker node's name on which the pod is running on.
+        Raises:
+            Exception: If there's an error while reading the current node name, it raises an exception.
+    """
     try:
         node_name = None
         logging.getLogger().info("\nReading current node name for pod %s " % obj.items[0].metadata.name)

--- a/test_terminating_delete.py
+++ b/test_terminating_delete.py
@@ -50,12 +50,23 @@ def test_terminating_pod_delete_statefulset():
 
         # Get pod object so that we can get node of pod to shut down kubelet on
         pod_obj = manager.hpe_list_pod_objects(statefulset.metadata.namespace, **labels)
-        nodename = manager.get_current_node_of_pod(pod_obj)
+        nodename = pod_obj.items[0].spec.node_name
         logging.getLogger().info("Nodename of the statefulset pod is %s" % nodename)
         manager.stop_kubelet(nodename)
 
         logging.getLogger().info("Sleeping for 7 minutes - let node get declared not ready and pods recreate")
-        sleep(420)
+        time = 0
+        kubelet_timeout = 420
+        while True:
+            if time % 60 == 0 and time > 0:
+                output_status = manager.status_kubelet(nodename)
+                logging.getLogger().info("Checking every minute for kubelet status, time :: %s" % time)
+                logging.getLogger().info("Kubelet Status on node %s:  %s" % (nodename ,output_status[0]))
+                assert output_status[0]  == "Inactive", "Status of kubelet is %s i.e not Inactive (dead)" % output_status[0]
+            if int(time) > int(kubelet_timeout):
+                break
+            time += 1
+            sleep(1)
         logging.getLogger().info("Over from sleeping... Starting kubelet back on node %s" % nodename)
 
         manager.start_kubelet(nodename)
@@ -66,6 +77,7 @@ def test_terminating_pod_delete_statefulset():
         # This can fail if other pods on same worker node are in Terminating state
         pod_terminating = manager.hpe_list_pod_objects(statefulset.metadata.namespace, **fields)
         count_pod_terminating = len(pod_terminating.items)
+        logging.getLogger().info("Checking terminating pods on node %s: %s" % (nodename, count_pod_terminating))
         assert count_pod_terminating == 0, "There are pods that are in Terminating state on the old worker node"
 
         # Check that the new pods are running (on another node)
@@ -81,7 +93,7 @@ def test_terminating_pod_delete_statefulset():
         )
 
         pod_obj = manager.hpe_list_pod_objects(statefulset.metadata.namespace, **labels)
-        current_nodename = manager.get_current_node_of_pod(pod_obj)
+        current_nodename = pod_obj.items[0].spec.node_name
         logging.getLogger().info("Nodename after simulating kubelet down is %s" % current_nodename)
 
         assert (
@@ -156,13 +168,24 @@ def test_terminating_deployment_with_pv():
 
         # Get pod object so that we can get node of pod to shut down kubelet on
         pod_obj = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **labels)
-        nodename = manager.get_current_node_of_pod(pod_obj)
+        nodename = pod_obj.items[0].spec.node_name
         logging.getLogger().info("Nodename of the deployment pod is %s" % nodename)
         manager.stop_kubelet(nodename)
 
         # Simulate the node down
         logging.getLogger().info("Sleeping for 7 minutes - let node get declared not ready and pods recreate")
-        sleep(420)
+        time = 0
+        kubelet_timeout = 420
+        while True:
+            if time % 60 == 0 and time > 0:
+                output_status = manager.status_kubelet(nodename)
+                logging.getLogger().info("Checking every minute for kubelet status, time :: %s" % time)
+                logging.getLogger().info("Kubelet Status on node %s:  %s" % (nodename ,output_status[0]))
+                assert output_status[0]  == "Inactive", "Status of kubelet is %s i.e not Inactive (dead)" % output_status[0]
+            if int(time) > int(kubelet_timeout):
+                break
+            time += 1
+            sleep(1)
 
         logging.getLogger().info("Over from sleeping... Starting kubelet back on node %s" % nodename)
         manager.start_kubelet(nodename)
@@ -174,6 +197,7 @@ def test_terminating_deployment_with_pv():
         # This can fail if other pods on same worker node are in Terminating state
         pod_terminating = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **fields)
         count_pod_terminating = len(pod_terminating.items)
+        logging.getLogger().info("Checking terminating pods on node %s: %s" % (nodename, count_pod_terminating))
         assert count_pod_terminating == 0, "There are pods that are in Terminating state on the old worker node"
 
         # Check that the new pods are running (on another node)
@@ -185,7 +209,7 @@ def test_terminating_deployment_with_pv():
         )
 
         pod_obj = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **labels)
-        current_nodename = manager.get_current_node_of_pod(pod_obj)
+        current_nodename = pod_obj.items[0].spec.node_name
         logging.getLogger().info("Nodename after simulating kubelet down is %s" % current_nodename)
 
         assert (
@@ -263,13 +287,24 @@ def test_terminating_deployment_without_pv():
 
         # Get pod object so that we can get node of pod to shut down kubelet on
         pod_obj = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **labels)
-        nodename = manager.get_current_node_of_pod(pod_obj)
+        nodename = pod_obj.items[0].spec.node_name
         logging.getLogger().info("Nodename of the deployment without pv pod is %s" % nodename)
         manager.stop_kubelet(nodename)
 
         # Simulate the node down
         logging.getLogger().info("Sleeping for 7 minutes - let node get declared not ready and pods recreate")
-        sleep(420)
+        time = 0
+        kubelet_timeout = 420
+        while True:
+            if time % 60 == 0 and time > 0:
+                output_status = manager.status_kubelet(nodename)
+                logging.getLogger().info("Checking every minute for kubelet status, time :: %s" % time)
+                logging.getLogger().info("Kubelet Status on node %s:  %s" % (nodename ,output_status[0]))
+                assert output_status[0]  == "Inactive", "Status of kubelet is %s i.e not Inactive (dead)" % output_status[0]
+            if int(time) > int(kubelet_timeout):
+                break
+            time += 1
+            sleep(1)
 
         logging.getLogger().info("Over from sleeping... Starting kubelet back on node %s" % nodename)
         manager.start_kubelet(nodename)
@@ -281,6 +316,7 @@ def test_terminating_deployment_without_pv():
         # This can fail if other pods on same worker node are in Terminating state
         pod_terminating = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **fields)
         count_pod_terminating = len(pod_terminating.items)
+        logging.getLogger().info("Checking terminating pods on node %s: %s" % (nodename, count_pod_terminating))
         assert count_pod_terminating == 0, "There are pods that are in Terminating state on the old worker node"
 
         # Check that the new pods are running (on another node)
@@ -292,7 +328,7 @@ def test_terminating_deployment_without_pv():
         )
 
         pod_obj = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **labels)
-        current_nodename = manager.get_current_node_of_pod(pod_obj)
+        current_nodename = pod_obj.items[0].spec.node_name
         logging.getLogger().info("Nodename after simulating kubelet down is %s" % current_nodename)
 
         assert (

--- a/test_terminating_delete.py
+++ b/test_terminating_delete.py
@@ -1,91 +1,109 @@
-import yaml
+"""
+Description: This script performs test cases relating to verifying if terminating pods
+are deleted during node down when using pod-monitor.
+Author: Anupama Vijayaraghavan
+Email: anupama.vijayaraghavan@hpe.com
+Date Created: 2024-09-18
+Version: 1.0
+"""
+
 import globals
-import pytest
 import hpe_3par_kubernetes_manager as manager
 import logging
 from time import sleep
-import time
 
 
 timeout = globals.status_check_timeout
-
 
 
 def test_terminating_pod_delete_statefulset():
     """
     Functional Test
 
-    To check if CSI monitored pod force-deletes the terminating StatefulSet pod, 
+    To check if CSI monitored pod force-deletes the terminating StatefulSet pod,
     when worker node goes down (through simulated kubelet down).
 
-    Passes if no terminating pods exist on old node, 
+    Passes if no terminating pods exist on old node,
     and new StatefulSet pod comes to Running state on another worker node.
 
-    """ 
-    secret = None 
+    """
     sc = None
     statefulset = None
     nodename = None
     try:
         yml = "%s/monitor-terminating-delete.yaml" % globals.yaml_dir
-        labels = {"label" : "app=monitor-statefulset"}
+        labels = {"label": "app=monitor-statefulset"}
         # Field for choosing the pods on a particular worker node to search for terminating pods
-        fields = {"field" : "status.phase=Terminating,spec.nodeName="}
-        
+        fields = {"field": "status.phase=Terminating,spec.nodeName="}
+
         sc = manager.create_sc(yml)
         statefulset = manager.create_statefulset(yml)
 
-        flag, sts_obj = manager.check_status(timeout, statefulset.metadata.name, kind='StatefulSet', status='Ready',
-                                         namespace=statefulset.metadata.namespace)
-        assert flag is True, "StatefulSet %s status check timed out, all replicas not ready..." % pvc_obj.metadata.name
+        flag, sts_obj = manager.check_status(
+            timeout,
+            statefulset.metadata.name,
+            kind="StatefulSet",
+            status="Ready",
+            namespace=statefulset.metadata.namespace,
+        )
+        assert flag is True, "StatefulSet %s status check timed out, all replicas not ready..." % sts_obj.metadata.name
 
-
-        #Get pod object so that we can get node of pod to shut down kubelet on
+        # Get pod object so that we can get node of pod to shut down kubelet on
         pod_obj = manager.hpe_list_pod_objects(statefulset.metadata.namespace, **labels)
         nodename = manager.get_current_node_of_pod(pod_obj)
         logging.getLogger().info("Nodename of the statefulset pod is %s" % nodename)
-        output = manager.stop_kubelet(nodename)
+        manager.stop_kubelet(nodename)
 
         logging.getLogger().info("Sleeping for 7 minutes - let node get declared not ready and pods recreate")
         sleep(420)
         logging.getLogger().info("Over from sleeping... Starting kubelet back on node %s" % nodename)
-        
-        output = manager.start_kubelet(nodename) 
-        fields['field'] = fields['field'] + nodename
-        logging.getLogger().info("Field selector with nodename: %s" % fields['field'])
+
+        manager.start_kubelet(nodename)
+        fields["field"] = fields["field"] + nodename
+        logging.getLogger().info("Field selector with nodename: %s" % fields["field"])
 
         # Assertion for no pods left in terminating state
         # This can fail if other pods on same worker node are in Terminating state
         pod_terminating = manager.hpe_list_pod_objects(statefulset.metadata.namespace, **fields)
         count_pod_terminating = len(pod_terminating.items)
-        assert count_pod_terminating is 0, "There are pods that are in Terminating state on the old worker node"
+        assert count_pod_terminating == 0, "There are pods that are in Terminating state on the old worker node"
 
         # Check that the new pods are running (on another node)
-        flag, sts_obj = manager.check_status(timeout, statefulset.metadata.name, kind='StatefulSet', status='Ready',
-                                         namespace=statefulset.metadata.namespace)
-        assert flag is True, "StatefulSet %s status check timed out, all replicas not ready on new node..." % pvc_obj.metadata.name
-        
+        flag, sts_obj = manager.check_status(
+            timeout,
+            statefulset.metadata.name,
+            kind="StatefulSet",
+            status="Ready",
+            namespace=statefulset.metadata.namespace,
+        )
+        assert flag is True, (
+            "StatefulSet %s status check timed out, all replicas not ready on new node..." % sts_obj.metadata.name
+        )
+
         pod_obj = manager.hpe_list_pod_objects(statefulset.metadata.namespace, **labels)
         current_nodename = manager.get_current_node_of_pod(pod_obj)
         logging.getLogger().info("Nodename after simulating kubelet down is %s" % current_nodename)
 
-        assert current_nodename is not nodename, "The two worker nodes are the same, pod did not recreate on another node"
+        assert (
+            current_nodename is not nodename
+        ), "The two worker nodes are the same, pod did not recreate on another node"
 
         assert manager.delete_statefulset(statefulset.metadata.name, statefulset.metadata.namespace)
 
         assert manager.delete_sc(sc.metadata.name) is True
 
-        assert manager.check_if_deleted(timeout, sc.metadata.name, "SC", sc.metadata.namespace) is True, "SC %s is not deleted yet " \
-                                                                                  % sc.metadata.name
+        assert manager.check_if_deleted(timeout, sc.metadata.name, "SC", sc.metadata.namespace) is True, (
+            "SC %s is not deleted yet " % sc.metadata.name
+        )
     except Exception as e:
         logging.getLogger().error("Exception in test_terminating_delete_statefulset :: %s" % e)
         raise e
 
     finally:
-        cleanup(None,sc,None,None,statefulset,None)
+        cleanup(None, sc, None, None, statefulset, None)
         if nodename is not None:
             manager.start_kubelet(nodename)
-		
+
 
 def test_terminating_deployment_with_pv():
     """
@@ -95,11 +113,10 @@ def test_terminating_deployment_with_pv():
     To check if CSI monitored pod force-deletes the terminating Deployment pod with PV,
     when worker node goes down (through simulated kubelet down).
 
-    Passes if: no terminating pods exist on old node, 
+    Passes if: no terminating pods exist on old node,
     and new Deployment With PV pod comes to Running state on another worker node.
 
-    """ 
-    secret = None 
+    """
     sc = None
     pvc = None
     service = None
@@ -110,14 +127,16 @@ def test_terminating_deployment_with_pv():
         yml = "%s/monitor-terminating-delete.yaml" % globals.yaml_dir
         dep_yml = "%s/with-pv-terminating-deployment.yaml" % globals.yaml_dir
         svc_yml = "%s/service-with-pv.yaml" % globals.yaml_dir
-        labels = {"label" : "app=nginx-with-pv"}
+        labels = {"label": "app=nginx-with-pv"}
         # Field for choosing the pods on a particular worker node to search for terminating pods
-        fields = {"field" : "status.phase=Terminating,spec.nodeName="}
+        fields = {"field": "status.phase=Terminating,spec.nodeName="}
 
         sc = manager.create_sc(yml)
         pvc = manager.create_pvc(yml)
 
-        flag, pvc_obj = manager.check_status(timeout, pvc.metadata.name, kind='pvc', status='Bound', namespace=pvc.metadata.namespace)
+        flag, pvc_obj = manager.check_status(
+            timeout, pvc.metadata.name, kind="pvc", status="Bound", namespace=pvc.metadata.namespace
+        )
         assert flag is True, "PVC %s status check timed out, not yet in Bound state.." % pvc.metadata.name
 
         pvc_crd = manager.get_pvc_crd(pvc_obj.spec.volume_name)
@@ -130,70 +149,79 @@ def test_terminating_deployment_with_pv():
 
         # Getting deployment object as only one deployment is created
         dep = [elem for elem in deployment.values()]
-        flag, dep_obj = manager.check_status(timeout, dep[0].metadata.name, kind='deployment', status='Ready',
-                                         namespace=dep[0].metadata.namespace)
+        flag, dep_obj = manager.check_status(
+            timeout, dep[0].metadata.name, kind="deployment", status="Ready", namespace=dep[0].metadata.namespace
+        )
         assert flag is True, "Deployment %s status check timed out, all replicas not ready..." % dep[0].metadata.name
 
         # Get pod object so that we can get node of pod to shut down kubelet on
         pod_obj = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **labels)
         nodename = manager.get_current_node_of_pod(pod_obj)
         logging.getLogger().info("Nodename of the deployment pod is %s" % nodename)
-        output = manager.stop_kubelet(nodename)
+        manager.stop_kubelet(nodename)
 
         # Simulate the node down
         logging.getLogger().info("Sleeping for 7 minutes - let node get declared not ready and pods recreate")
         sleep(420)
 
         logging.getLogger().info("Over from sleeping... Starting kubelet back on node %s" % nodename)
-        output = manager.start_kubelet(nodename) 
+        manager.start_kubelet(nodename)
 
-        fields['field'] = fields['field'] + nodename
-        logging.getLogger().info("Field selector with nodename: %s" % fields['field'])
+        fields["field"] = fields["field"] + nodename
+        logging.getLogger().info("Field selector with nodename: %s" % fields["field"])
 
         # Assertion for no pods left in terminating state
         # This can fail if other pods on same worker node are in Terminating state
         pod_terminating = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **fields)
         count_pod_terminating = len(pod_terminating.items)
-        assert count_pod_terminating is 0, "There are pods that are in Terminating state on the old worker node"
+        assert count_pod_terminating == 0, "There are pods that are in Terminating state on the old worker node"
 
         # Check that the new pods are running (on another node)
-        flag, dep_obj = manager.check_status(timeout, dep[0].metadata.name, kind='deployment', status='Ready',
-                                         namespace=dep[0].metadata.namespace)
-        assert flag is True, "Deployment %s status check timed out, all replicas not ready on new node..." % dep[0].metadata.name
+        flag, dep_obj = manager.check_status(
+            timeout, dep[0].metadata.name, kind="deployment", status="Ready", namespace=dep[0].metadata.namespace
+        )
+        assert flag is True, (
+            "Deployment %s status check timed out, all replicas not ready on new node..." % dep[0].metadata.name
+        )
 
         pod_obj = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **labels)
         current_nodename = manager.get_current_node_of_pod(pod_obj)
         logging.getLogger().info("Nodename after simulating kubelet down is %s" % current_nodename)
 
-        assert current_nodename is not nodename, "The two worker nodes are the same, pod did not recreate on another node"
-        
+        assert (
+            current_nodename is not nodename
+        ), "The two worker nodes are the same, pod did not recreate on another node"
+
         manager.delete_dep_bulk(dep_yml, globals.namespace)
 
-        assert manager.check_if_deleted(2,dep[0].metadata.name, "Deploy", namespace=dep[0].metadata.namespace) is True, \
-                                                             "Deployment %s is not deleted yet..." % dep[0].metadata.name
-                                                             
+        assert (
+            manager.check_if_deleted(2, dep[0].metadata.name, "Deploy", namespace=dep[0].metadata.namespace) is True
+        ), ("Deployment %s is not deleted yet..." % dep[0].metadata.name)
+
         # If deployment was deleted, set dep_yml to None so that cleanup doesn't happen twice
         dep_yml = None
-        
+
         assert manager.delete_service(service.metadata.name, service.metadata.namespace) is True
-        
-        assert manager.check_if_deleted(2, service.metadata.name, "Service", namespace=service.metadata.namespace) is True, \
-                                                                            "Service %s is not deleted yet " % service.metadata.name
+
+        assert (
+            manager.check_if_deleted(2, service.metadata.name, "Service", namespace=service.metadata.namespace) is True
+        ), ("Service %s is not deleted yet " % service.metadata.name)
 
         assert manager.delete_sc(sc.metadata.name) is True
 
-        assert manager.check_if_deleted(timeout, sc.metadata.name, "SC", sc.metadata.namespace) is True, "SC %s is not deleted yet " \
-                                                                                  % sc.metadata.name
+        assert manager.check_if_deleted(timeout, sc.metadata.name, "SC", sc.metadata.namespace) is True, (
+            "SC %s is not deleted yet " % sc.metadata.name
+        )
     except Exception as e:
         logging.getLogger().error("Exception in test_terminating_deployment_with_pv :: %s" % e)
         raise e
 
     finally:
         if dep_yml is not None:
-            cleanup(None,None,None,None,None,dep_yml)
-        cleanup(None,sc,pvc,service,None,None)
+            cleanup(None, None, None, None, None, dep_yml)
+        cleanup(None, sc, pvc, service, None, None)
         if nodename is not None:
-            manager.start_kubelet(nodename)    
+            manager.start_kubelet(nodename)
 
 
 def test_terminating_deployment_without_pv():
@@ -204,11 +232,10 @@ def test_terminating_deployment_without_pv():
     To check if CSI force-deletes the deployment without pv terminating pod,
     when worker node goes down (through simulated kubelet down).
 
-    Passes if: no terminating pods exist on old node, 
+    Passes if: no terminating pods exist on old node,
     and new Deployment without PV pod comes to Running state on another worker node.
 
-    """ 
-    secret = None 
+    """
     sc = None
     service = None
     deployment = None
@@ -218,9 +245,9 @@ def test_terminating_deployment_without_pv():
         yml = "%s/monitor-terminating-delete.yaml" % globals.yaml_dir
         dep_yml = "%s/without-pv-terminating-deployment.yaml" % globals.yaml_dir
         svc_yml = "%s/service-without-pv.yaml" % globals.yaml_dir
-        labels = {"label" : "app=nginx-without-pv"}
+        labels = {"label": "app=nginx-without-pv"}
         # Field for choosing the pods on a particular worker node to search for terminating pods
-        fields = {"field" : "status.phase=Terminating,spec.nodeName="}
+        fields = {"field": "status.phase=Terminating,spec.nodeName="}
 
         sc = manager.create_sc(yml)
         service = manager.create_service(svc_yml)
@@ -229,83 +256,103 @@ def test_terminating_deployment_without_pv():
         # Getting deployment object as only 1 deployment is created
         dep = [elem for elem in deployment.values()]
 
-        flag, dep_obj = manager.check_status(timeout, dep[0].metadata.name, kind='deployment', status='Ready',
-                                         namespace=dep[0].metadata.namespace)
+        flag, dep_obj = manager.check_status(
+            timeout, dep[0].metadata.name, kind="deployment", status="Ready", namespace=dep[0].metadata.namespace
+        )
         assert flag is True, "Deployment %s status check timed out, all replicas not ready..." % dep[0].metadata.name
 
         # Get pod object so that we can get node of pod to shut down kubelet on
         pod_obj = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **labels)
         nodename = manager.get_current_node_of_pod(pod_obj)
         logging.getLogger().info("Nodename of the deployment without pv pod is %s" % nodename)
-        output = manager.stop_kubelet(nodename)
+        manager.stop_kubelet(nodename)
 
         # Simulate the node down
         logging.getLogger().info("Sleeping for 7 minutes - let node get declared not ready and pods recreate")
         sleep(420)
 
         logging.getLogger().info("Over from sleeping... Starting kubelet back on node %s" % nodename)
-        output = manager.start_kubelet(nodename) 
+        manager.start_kubelet(nodename)
 
-        fields['field'] = fields['field'] + nodename
-        logging.getLogger().info("Field selector with nodename: %s" % fields['field'])
+        fields["field"] = fields["field"] + nodename
+        logging.getLogger().info("Field selector with nodename: %s" % fields["field"])
 
         # Assertion for no pods left in terminating state
         # This can fail if other pods on same worker node are in Terminating state
         pod_terminating = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **fields)
         count_pod_terminating = len(pod_terminating.items)
-        assert count_pod_terminating is 0, "There are pods that are in Terminating state on the old worker node"
+        assert count_pod_terminating == 0, "There are pods that are in Terminating state on the old worker node"
 
         # Check that the new pods are running (on another node)
-        flag, dep_obj = manager.check_status(timeout, dep[0].metadata.name, kind='deployment', status='Ready',
-                                         namespace=dep[0].metadata.namespace)
-        assert flag is True, "Deployment %s status check timed out, all replicas not ready on new node..." % dep[0].metadata.name
+        flag, dep_obj = manager.check_status(
+            timeout, dep[0].metadata.name, kind="deployment", status="Ready", namespace=dep[0].metadata.namespace
+        )
+        assert flag is True, (
+            "Deployment %s status check timed out, all replicas not ready on new node..." % dep[0].metadata.name
+        )
 
         pod_obj = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **labels)
         current_nodename = manager.get_current_node_of_pod(pod_obj)
         logging.getLogger().info("Nodename after simulating kubelet down is %s" % current_nodename)
 
-        assert current_nodename is not nodename, "The two worker nodes are the same, pod did not recreate on another node"
-        
+        assert (
+            current_nodename is not nodename
+        ), "The two worker nodes are the same, pod did not recreate on another node"
+
         manager.delete_dep_bulk(dep_yml, globals.namespace)
 
-        assert manager.check_if_deleted(2,dep[0].metadata.name, "Deploy", namespace=dep[0].metadata.namespace) is True, \
-                                                             "Deployment %s is not deleted yet..." % dep[0].metadata.name
+        assert (
+            manager.check_if_deleted(2, dep[0].metadata.name, "Deploy", namespace=dep[0].metadata.namespace) is True
+        ), ("Deployment %s is not deleted yet..." % dep[0].metadata.name)
 
         # If deployment was deleted, set dep_yml to None so that cleanup doesn't happen twice
         dep_yml = None
-        
+
         assert manager.delete_service(service.metadata.name, service.metadata.namespace) is True
-        
-        assert manager.check_if_deleted(2, service.metadata.name, "Service", namespace=service.metadata.namespace) is True, \
-                                                                             "Service %s is not deleted yet "  % service.metadata.name
+
+        assert (
+            manager.check_if_deleted(2, service.metadata.name, "Service", namespace=service.metadata.namespace) is True
+        ), ("Service %s is not deleted yet " % service.metadata.name)
 
         assert manager.delete_sc(sc.metadata.name) is True
 
-        assert manager.check_if_deleted(timeout, sc.metadata.name, "SC", sc.metadata.namespace) is True, "SC %s is not deleted yet " \
-                                                                                  % sc.metadata.name
+        assert manager.check_if_deleted(timeout, sc.metadata.name, "SC", sc.metadata.namespace) is True, (
+            "SC %s is not deleted yet " % sc.metadata.name
+        )
     except Exception as e:
         logging.getLogger().error("Exception in test_terminating_deployment_without_pv :: %s" % e)
         raise e
 
     finally:
         if dep_yml is not None:
-            cleanup(None,None,None,None,None,dep_yml)
-        cleanup(None,sc,None,service,None,None)
+            cleanup(None, None, None, None, None, dep_yml)
+        cleanup(None, sc, None, service, None, None)
         if nodename is not None:
-            manager.start_kubelet(nodename)   
-    
+            manager.start_kubelet(nodename)
 
 
 def cleanup(secret, sc, pvc, svc, statefulset, deployment):
     logging.getLogger().info("====== cleanup :START =========")
-    if statefulset is not None and manager.check_if_deleted(2, statefulset.metadata.name, "StatefulSet", namespace=statefulset.metadata.namespace) is False:
+    if (
+        statefulset is not None
+        and manager.check_if_deleted(
+            2, statefulset.metadata.name, "StatefulSet", namespace=statefulset.metadata.namespace
+        )
+        is False
+    ):
         manager.delete_statefulset(statefulset.metadata.name, statefulset.metadata.namespace)
     if deployment is not None:
         logging.getLogger().info("Deleting deployment...")
         manager.delete_dep_bulk(deployment, globals.namespace)
-    if svc is not None and manager.check_if_deleted(2, svc.metadata.name, "Service", namespace=svc.metadata.namespace) is False:
-                assert manager.delete_service(svc.metadata.name, svc.metadata.namespace)
-    if pvc is not None and manager.check_if_deleted(2, pvc.metadata.name, "PVC", namespace=pvc.metadata.namespace) is False:
+    if (
+        svc is not None
+        and manager.check_if_deleted(2, svc.metadata.name, "Service", namespace=svc.metadata.namespace) is False
+    ):
+        assert manager.delete_service(svc.metadata.name, svc.metadata.namespace)
+    if (
+        pvc is not None
+        and manager.check_if_deleted(2, pvc.metadata.name, "PVC", namespace=pvc.metadata.namespace) is False
+    ):
         manager.delete_pvc(pvc.metadata.name)
     if sc is not None and manager.check_if_deleted(2, sc.metadata.name, "SC", namespace=sc.metadata.namespace) is False:
         manager.delete_sc(sc.metadata.name)

--- a/test_terminating_delete.py
+++ b/test_terminating_delete.py
@@ -1,0 +1,312 @@
+import yaml
+import globals
+import pytest
+import hpe_3par_kubernetes_manager as manager
+import logging
+from time import sleep
+import time
+
+
+timeout = globals.status_check_timeout
+
+
+
+def test_terminating_pod_delete_statefulset():
+    """
+    Functional Test
+
+    To check if CSI monitored pod force-deletes the terminating StatefulSet pod, 
+    when worker node goes down (through simulated kubelet down).
+
+    Passes if no terminating pods exist on old node, 
+    and new StatefulSet pod comes to Running state on another worker node.
+
+    """ 
+    secret = None 
+    sc = None
+    statefulset = None
+    nodename = None
+    try:
+        yml = "%s/monitor-terminating-delete.yaml" % globals.yaml_dir
+        labels = {"label" : "app=monitor-statefulset"}
+        # Field for choosing the pods on a particular worker node to search for terminating pods
+        fields = {"field" : "status.phase=Terminating,spec.nodeName="}
+        
+        sc = manager.create_sc(yml)
+        statefulset = manager.create_statefulset(yml)
+
+        flag, sts_obj = manager.check_status(timeout, statefulset.metadata.name, kind='StatefulSet', status='Ready',
+                                         namespace=statefulset.metadata.namespace)
+        assert flag is True, "StatefulSet %s status check timed out, all replicas not ready..." % pvc_obj.metadata.name
+
+
+        #Get pod object so that we can get node of pod to shut down kubelet on
+        pod_obj = manager.hpe_list_pod_objects(statefulset.metadata.namespace, **labels)
+        nodename = manager.get_current_node_of_pod(pod_obj)
+        logging.getLogger().info("Nodename of the statefulset pod is %s" % nodename)
+        output = manager.stop_kubelet(nodename)
+
+        logging.getLogger().info("Sleeping for 7 minutes - let node get declared not ready and pods recreate")
+        sleep(420)
+        logging.getLogger().info("Over from sleeping... Starting kubelet back on node %s" % nodename)
+        
+        output = manager.start_kubelet(nodename) 
+        fields['field'] = fields['field'] + nodename
+        logging.getLogger().info("Field selector with nodename: %s" % fields['field'])
+
+        # Assertion for no pods left in terminating state
+        # This can fail if other pods on same worker node are in Terminating state
+        pod_terminating = manager.hpe_list_pod_objects(statefulset.metadata.namespace, **fields)
+        count_pod_terminating = len(pod_terminating.items)
+        assert count_pod_terminating is 0, "There are pods that are in Terminating state on the old worker node"
+
+        # Check that the new pods are running (on another node)
+        flag, sts_obj = manager.check_status(timeout, statefulset.metadata.name, kind='StatefulSet', status='Ready',
+                                         namespace=statefulset.metadata.namespace)
+        assert flag is True, "StatefulSet %s status check timed out, all replicas not ready on new node..." % pvc_obj.metadata.name
+        
+        pod_obj = manager.hpe_list_pod_objects(statefulset.metadata.namespace, **labels)
+        current_nodename = manager.get_current_node_of_pod(pod_obj)
+        logging.getLogger().info("Nodename after simulating kubelet down is %s" % current_nodename)
+
+        assert current_nodename is not nodename, "The two worker nodes are the same, pod did not recreate on another node"
+
+        assert manager.delete_statefulset(statefulset.metadata.name, statefulset.metadata.namespace)
+
+        assert manager.delete_sc(sc.metadata.name) is True
+
+        assert manager.check_if_deleted(timeout, sc.metadata.name, "SC", sc.metadata.namespace) is True, "SC %s is not deleted yet " \
+                                                                                  % sc.metadata.name
+    except Exception as e:
+        logging.getLogger().error("Exception in test_terminating_delete_statefulset :: %s" % e)
+        raise e
+
+    finally:
+        cleanup(None,sc,None,None,statefulset,None)
+        if nodename is not None:
+            manager.start_kubelet(nodename)
+		
+
+def test_terminating_deployment_with_pv():
+    """
+
+    Functional Test
+
+    To check if CSI monitored pod force-deletes the terminating Deployment pod with PV,
+    when worker node goes down (through simulated kubelet down).
+
+    Passes if: no terminating pods exist on old node, 
+    and new Deployment With PV pod comes to Running state on another worker node.
+
+    """ 
+    secret = None 
+    sc = None
+    pvc = None
+    service = None
+    deployment = None
+    dep_yml = None
+    nodename = None
+    try:
+        yml = "%s/monitor-terminating-delete.yaml" % globals.yaml_dir
+        dep_yml = "%s/with-pv-terminating-deployment.yaml" % globals.yaml_dir
+        svc_yml = "%s/service-with-pv.yaml" % globals.yaml_dir
+        labels = {"label" : "app=nginx-with-pv"}
+        # Field for choosing the pods on a particular worker node to search for terminating pods
+        fields = {"field" : "status.phase=Terminating,spec.nodeName="}
+
+        sc = manager.create_sc(yml)
+        pvc = manager.create_pvc(yml)
+
+        flag, pvc_obj = manager.check_status(timeout, pvc.metadata.name, kind='pvc', status='Bound', namespace=pvc.metadata.namespace)
+        assert flag is True, "PVC %s status check timed out, not yet in Bound state.." % pvc.metadata.name
+
+        pvc_crd = manager.get_pvc_crd(pvc_obj.spec.volume_name)
+        volume_name = manager.get_pvc_volume(pvc_crd)
+        volume = manager.get_volume_from_array(globals.hpe3par_cli, volume_name)
+        assert volume is not None, "Volume is not created on 3PAR for pvc %s " % volume_name
+
+        service = manager.create_service(svc_yml)
+        deployment = manager.create_dep_bulk(dep_yml, globals.namespace)
+
+        # Getting deployment object as only one deployment is created
+        dep = [elem for elem in deployment.values()]
+        flag, dep_obj = manager.check_status(timeout, dep[0].metadata.name, kind='deployment', status='Ready',
+                                         namespace=dep[0].metadata.namespace)
+        assert flag is True, "Deployment %s status check timed out, all replicas not ready..." % dep[0].metadata.name
+
+        # Get pod object so that we can get node of pod to shut down kubelet on
+        pod_obj = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **labels)
+        nodename = manager.get_current_node_of_pod(pod_obj)
+        logging.getLogger().info("Nodename of the deployment pod is %s" % nodename)
+        output = manager.stop_kubelet(nodename)
+
+        # Simulate the node down
+        logging.getLogger().info("Sleeping for 7 minutes - let node get declared not ready and pods recreate")
+        sleep(420)
+
+        logging.getLogger().info("Over from sleeping... Starting kubelet back on node %s" % nodename)
+        output = manager.start_kubelet(nodename) 
+
+        fields['field'] = fields['field'] + nodename
+        logging.getLogger().info("Field selector with nodename: %s" % fields['field'])
+
+        # Assertion for no pods left in terminating state
+        # This can fail if other pods on same worker node are in Terminating state
+        pod_terminating = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **fields)
+        count_pod_terminating = len(pod_terminating.items)
+        assert count_pod_terminating is 0, "There are pods that are in Terminating state on the old worker node"
+
+        # Check that the new pods are running (on another node)
+        flag, dep_obj = manager.check_status(timeout, dep[0].metadata.name, kind='deployment', status='Ready',
+                                         namespace=dep[0].metadata.namespace)
+        assert flag is True, "Deployment %s status check timed out, all replicas not ready on new node..." % dep[0].metadata.name
+
+        pod_obj = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **labels)
+        current_nodename = manager.get_current_node_of_pod(pod_obj)
+        logging.getLogger().info("Nodename after simulating kubelet down is %s" % current_nodename)
+
+        assert current_nodename is not nodename, "The two worker nodes are the same, pod did not recreate on another node"
+        
+        manager.delete_dep_bulk(dep_yml, globals.namespace)
+
+        assert manager.check_if_deleted(2,dep[0].metadata.name, "Deploy", namespace=dep[0].metadata.namespace) is True, \
+                                                             "Deployment %s is not deleted yet..." % dep[0].metadata.name
+                                                             
+        # If deployment was deleted, set dep_yml to None so that cleanup doesn't happen twice
+        dep_yml = None
+        
+        assert manager.delete_service(service.metadata.name, service.metadata.namespace) is True
+        
+        assert manager.check_if_deleted(2, service.metadata.name, "Service", namespace=service.metadata.namespace) is True, \
+                                                                            "Service %s is not deleted yet " % service.metadata.name
+
+        assert manager.delete_sc(sc.metadata.name) is True
+
+        assert manager.check_if_deleted(timeout, sc.metadata.name, "SC", sc.metadata.namespace) is True, "SC %s is not deleted yet " \
+                                                                                  % sc.metadata.name
+    except Exception as e:
+        logging.getLogger().error("Exception in test_terminating_deployment_with_pv :: %s" % e)
+        raise e
+
+    finally:
+        if dep_yml is not None:
+            cleanup(None,None,None,None,None,dep_yml)
+        cleanup(None,sc,pvc,service,None,None)
+        if nodename is not None:
+            manager.start_kubelet(nodename)    
+
+
+def test_terminating_deployment_without_pv():
+    """
+
+    Functional Test
+
+    To check if CSI force-deletes the deployment without pv terminating pod,
+    when worker node goes down (through simulated kubelet down).
+
+    Passes if: no terminating pods exist on old node, 
+    and new Deployment without PV pod comes to Running state on another worker node.
+
+    """ 
+    secret = None 
+    sc = None
+    service = None
+    deployment = None
+    dep_yml = None
+    nodename = None
+    try:
+        yml = "%s/monitor-terminating-delete.yaml" % globals.yaml_dir
+        dep_yml = "%s/without-pv-terminating-deployment.yaml" % globals.yaml_dir
+        svc_yml = "%s/service-without-pv.yaml" % globals.yaml_dir
+        labels = {"label" : "app=nginx-without-pv"}
+        # Field for choosing the pods on a particular worker node to search for terminating pods
+        fields = {"field" : "status.phase=Terminating,spec.nodeName="}
+
+        sc = manager.create_sc(yml)
+        service = manager.create_service(svc_yml)
+        deployment = manager.create_dep_bulk(dep_yml, globals.namespace)
+
+        # Getting deployment object as only 1 deployment is created
+        dep = [elem for elem in deployment.values()]
+
+        flag, dep_obj = manager.check_status(timeout, dep[0].metadata.name, kind='deployment', status='Ready',
+                                         namespace=dep[0].metadata.namespace)
+        assert flag is True, "Deployment %s status check timed out, all replicas not ready..." % dep[0].metadata.name
+
+        # Get pod object so that we can get node of pod to shut down kubelet on
+        pod_obj = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **labels)
+        nodename = manager.get_current_node_of_pod(pod_obj)
+        logging.getLogger().info("Nodename of the deployment without pv pod is %s" % nodename)
+        output = manager.stop_kubelet(nodename)
+
+        # Simulate the node down
+        logging.getLogger().info("Sleeping for 7 minutes - let node get declared not ready and pods recreate")
+        sleep(420)
+
+        logging.getLogger().info("Over from sleeping... Starting kubelet back on node %s" % nodename)
+        output = manager.start_kubelet(nodename) 
+
+        fields['field'] = fields['field'] + nodename
+        logging.getLogger().info("Field selector with nodename: %s" % fields['field'])
+
+        # Assertion for no pods left in terminating state
+        # This can fail if other pods on same worker node are in Terminating state
+        pod_terminating = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **fields)
+        count_pod_terminating = len(pod_terminating.items)
+        assert count_pod_terminating is 0, "There are pods that are in Terminating state on the old worker node"
+
+        # Check that the new pods are running (on another node)
+        flag, dep_obj = manager.check_status(timeout, dep[0].metadata.name, kind='deployment', status='Ready',
+                                         namespace=dep[0].metadata.namespace)
+        assert flag is True, "Deployment %s status check timed out, all replicas not ready on new node..." % dep[0].metadata.name
+
+        pod_obj = manager.hpe_list_pod_objects(dep[0].metadata.namespace, **labels)
+        current_nodename = manager.get_current_node_of_pod(pod_obj)
+        logging.getLogger().info("Nodename after simulating kubelet down is %s" % current_nodename)
+
+        assert current_nodename is not nodename, "The two worker nodes are the same, pod did not recreate on another node"
+        
+        manager.delete_dep_bulk(dep_yml, globals.namespace)
+
+        assert manager.check_if_deleted(2,dep[0].metadata.name, "Deploy", namespace=dep[0].metadata.namespace) is True, \
+                                                             "Deployment %s is not deleted yet..." % dep[0].metadata.name
+
+        # If deployment was deleted, set dep_yml to None so that cleanup doesn't happen twice
+        dep_yml = None
+        
+        assert manager.delete_service(service.metadata.name, service.metadata.namespace) is True
+        
+        assert manager.check_if_deleted(2, service.metadata.name, "Service", namespace=service.metadata.namespace) is True, \
+                                                                             "Service %s is not deleted yet "  % service.metadata.name
+
+        assert manager.delete_sc(sc.metadata.name) is True
+
+        assert manager.check_if_deleted(timeout, sc.metadata.name, "SC", sc.metadata.namespace) is True, "SC %s is not deleted yet " \
+                                                                                  % sc.metadata.name
+    except Exception as e:
+        logging.getLogger().error("Exception in test_terminating_deployment_without_pv :: %s" % e)
+        raise e
+
+    finally:
+        if dep_yml is not None:
+            cleanup(None,None,None,None,None,dep_yml)
+        cleanup(None,sc,None,service,None,None)
+        if nodename is not None:
+            manager.start_kubelet(nodename)   
+    
+
+
+def cleanup(secret, sc, pvc, svc, statefulset, deployment):
+    logging.getLogger().info("====== cleanup :START =========")
+    if statefulset is not None and manager.check_if_deleted(2, statefulset.metadata.name, "StatefulSet", namespace=statefulset.metadata.namespace) is False:
+        manager.delete_statefulset(statefulset.metadata.name, statefulset.metadata.namespace)
+    if deployment is not None:
+        logging.getLogger().info("Deleting deployment...")
+        manager.delete_dep_bulk(deployment, globals.namespace)
+    if svc is not None and manager.check_if_deleted(2, svc.metadata.name, "Service", namespace=svc.metadata.namespace) is False:
+                assert manager.delete_service(svc.metadata.name, svc.metadata.namespace)
+    if pvc is not None and manager.check_if_deleted(2, pvc.metadata.name, "PVC", namespace=pvc.metadata.namespace) is False:
+        manager.delete_pvc(pvc.metadata.name)
+    if sc is not None and manager.check_if_deleted(2, sc.metadata.name, "SC", namespace=sc.metadata.namespace) is False:
+        manager.delete_sc(sc.metadata.name)
+    logging.getLogger().info("====== cleanup :END =========")

--- a/yaml/monitor-terminating-delete.yaml
+++ b/yaml/monitor-terminating-delete.yaml
@@ -1,0 +1,77 @@
+--- 
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ci-sc-monitor-terminating-delete
+provisioner: csi.hpe.com
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  csi.storage.k8s.io/provisioner-secret-name: ci-primera3par-csp-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: hpe-storage
+  csi.storage.k8s.io/controller-publish-secret-name: ci-primera3par-csp-secret
+  csi.storage.k8s.io/controller-publish-secret-namespace: hpe-storage
+  csi.storage.k8s.io/node-stage-secret-name: ci-primera3par-csp-secret
+  csi.storage.k8s.io/node-stage-secret-namespace: hpe-storage
+  csi.storage.k8s.io/node-publish-secret-name: ci-primera3par-csp-secret
+  csi.storage.k8s.io/node-publish-secret-namespace: hpe-storage
+  accessProtocol: "iscsi"
+  cpg: CI_CPG
+
+---
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: ci-pvc-monitor-terminate-delete
+  namespace: hpe-storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: ci-sc-monitor-terminating-delete
+
+---
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ci-monitor-delete-stfset
+  namespace: hpe-storage
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+  serviceName: centos
+  replicas: 1
+  selector:
+    matchLabels:
+      app: monitor-statefulset
+  template:
+    metadata:
+      labels:
+        monitored-by: hpe-csi
+        app: monitor-statefulset
+    spec:
+      containers:
+      - name: centos
+        image: centos
+        command:
+        - sleep
+        - '3600000'
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: centos-sts-pv
+          mountPath: /data
+  volumeClaimTemplates:
+  - metadata:
+      name: centos-sts-pv
+    spec:
+      storageClassName: ci-sc-monitor-terminating-delete
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 3Gi
+
+                

--- a/yaml/service-with-pv.yaml
+++ b/yaml/service-with-pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-svc-pv
+  namespace: hpe-storage
+  labels:
+    app: nginx-service-pv
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+  selector:
+    app: nginx-service-pv

--- a/yaml/service-without-pv.yaml
+++ b/yaml/service-without-pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-svc
+  namespace: hpe-storage
+  labels:
+    app: nginx-service
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+  selector:
+    app: nginx-service

--- a/yaml/with-pv-terminating-deployment.yaml
+++ b/yaml/with-pv-terminating-deployment.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ci-monitor-delete-dep-with-pv
+  namespace: hpe-storage
+spec:
+  selector:
+    matchLabels:
+      app: nginx-with-pv
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        monitored-by: hpe-csi
+        app: nginx-with-pv
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - mountPath: /usr/share/nginx/html/
+          name: nginx-index
+      volumes:
+      - name: nginx-index
+        persistentVolumeClaim:
+          claimName: ci-pvc-monitor-terminate-delete
+      initContainers:
+      - name: init01
+        image: centos:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: VES_IO_SITENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        args:
+        - /bin/sh
+        - -c
+        - echo $VES_IO_SITENAME $HOSTNAME >> /tmp/index.html
+        volumeMounts:
+        - mountPath: /tmp
+          name: nginx-index

--- a/yaml/without-pv-terminating-deployment.yaml
+++ b/yaml/without-pv-terminating-deployment.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ci-monitor-delete-dep-without-pv
+  namespace: hpe-storage
+spec:
+  selector:
+    matchLabels:
+      app: nginx-without-pv
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        monitored-by: hpe-csi
+        app: nginx-without-pv
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - mountPath: /usr/share/nginx/html/
+          name: nginx-index
+      volumes:
+      - name: nginx-index
+        emptyDir: {}
+      initContainers:
+      - name: init01
+        image: centos:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: VES_IO_SITENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        args:
+        - /bin/sh
+        - -c
+        - echo $VES_IO_SITENAME $HOSTNAME >> /tmp/index.html
+        volumeMounts:
+        - mountPath: /tmp
+          name: nginx-index


### PR DESCRIPTION
Brief Description:
* Added three functional testcases in Terminating Pod Force-Delete with pod-monitor when node goes down (through simulated kubelet down) and check for force-delete of the terminating pods and new pods to come up into Running on another node.

* Added also try-except for session logout which caused authentication issue with DELETE call for wsapisession. 

Logs:
Jenkins (Arcus R4 Prime) https://jenkins-ring234-cxo.eng.nimblestorage.com/job/ESI-2410-Force-Delete/15/console
(Primera) https://jenkins-ring234-cxo.eng.nimblestorage.com/job/ESI-2410-Force-Delete/16/console
